### PR TITLE
Update braintree SDK

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -55,6 +55,6 @@ repositories {
 dependencies {
     api 'com.facebook.react:react-native:+'
 
-    compileOnly 'com.braintreepayments.api:braintree:3.+'
-    compileOnly 'com.braintreepayments.api:data-collector:3.+'
+    compileOnly 'com.braintreepayments.api:braintree:3.21.0'
+    compileOnly 'com.braintreepayments.api:data-collector:3.21.0'
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
   
   <application android:label="@string/app_name">
     <activity android:name="com.braintreepayments.api.BraintreeBrowserSwitchActivity"
+      android:exported="true"
       android:launchMode="singleTask"
       android:theme="@android:style/Theme.Translucent.NoTitleBar">
       <intent-filter>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-paypal",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "React Native library that implements PayPal Checkout flow using purely native code",
   "main": "index.js",
   "typings": "index.d.ts",
@@ -17,12 +17,12 @@
     "ios",
     "payment"
   ],
-  "author": "Smarkets Ltd",
+  "author": "Emil Welton",
   "license": "MIT",
-  "homepage": "https://github.com/smarkets/react-native-paypal#readme",
+  "homepage": "https://github.com/emil-98/react-native-paypal#readme",
   "repository": {
     "type": "git",
-    "url": "git@github.com:smarkets/react-native-paypal.git"
+    "url": "git@github.com:emil-98/react-native-paypal.git"
   },
   "peerDependencies": {
     "react-native": ">=0.41.2"


### PR DESCRIPTION
Changed braintree version to 3.21.0 per Google Play's suggestion, added `android:exported="true"` to BraintreeBrowserSwitchActivity in AndroidManifest.xml